### PR TITLE
Fix login variable names

### DIFF
--- a/teebay-frontend/src/pages/LoginPage.tsx
+++ b/teebay-frontend/src/pages/LoginPage.tsx
@@ -41,11 +41,11 @@ export default function LoginPage() {
 
   const [validateLogin, { loading }] = useMutation(LOGIN);
 
-  const handleSubmit = async (values: LoginFormValues) => {
+  const handleSubmit = async (formValues: LoginFormValues) => {
     setErrorMessage('');
     try {
       const res = await validateLogin({
-        variables: { handle: values.handle, password: values.password },
+        variables: { handle: formValues.handle, password: formValues.password },
       });
       const user = res.data.login;
       login({ id: user.id, username: user.username });


### PR DESCRIPTION
## Summary
- fix GraphQL variable names in `LoginPage` to reference the form values

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in `teebay-api` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c41580dac8322ae8810e53a172971